### PR TITLE
言語切り替えリンク

### DIFF
--- a/docs/en/_toc.yml
+++ b/docs/en/_toc.yml
@@ -4,6 +4,10 @@
 format: jb-book
 root: getting_started
 parts:
+  - caption: Switch Language
+    chapters:
+      - url: https://jij-inc.github.io/JijModeling-Tutorials/ja/
+        title: 日本語
   - caption: "Tutorials"
     chapters:
       - file: tutorials/creating_models

--- a/docs/ja/_toc.yml
+++ b/docs/ja/_toc.yml
@@ -4,6 +4,10 @@
 format: jb-book
 root: introduction
 parts:
+  - caption: Switch Language
+    chapters:
+      - url: https://jij-inc.github.io/JijModeling-Tutorials/en/
+        title: English
   - caption: "クイックスタート"
     chapters:
       - file: quickstart/scip


### PR DESCRIPTION
- 日本語・英語のドキュメントから、もう一方の先頭ページに飛ぶリンクを作ります
- 個々のページ単位でのジャンプは行いません
