### PR TITLE
Update to new OMMX Adapter API

### DIFF
--- a/docs/en/quickstart/scip.ipynb
+++ b/docs/en/quickstart/scip.ipynb
@@ -93,7 +93,7 @@
        "$$\\begin{array}{cccc}\\text{Problem:} & \\text{problem} & & \\\\& & \\max \\quad \\displaystyle \\sum_{i = 0}^{N - 1} v_{i} \\cdot x_{i} & \\\\\\text{{s.t.}} & & & \\\\ & \\text{Weight Constraint} & \\displaystyle \\sum_{i = 0}^{N - 1} w_{i} \\cdot x_{i} \\leq W &  \\\\\\text{{where}} & & & \\\\& x & 1\\text{-dim binary variable}\\\\\\end{array}$$"
       ],
       "text/plain": [
-       "<jijmodeling.Problem at 0x12567f6f0>"
+       "<jijmodeling.Problem at 0x5cf055f42e80>"
       ]
      },
      "execution_count": 1,
@@ -209,17 +209,21 @@
      "text": [
       "Optimal value of the objective function: 41.0\n"
      ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/zengor/jij/JijModeling-Tutorials/.venv/lib/python3.9/site-packages/ommx_pyscipopt_adapter/adapter.py:30: UserWarning: linked SCIP 9.02 is not recommended for this version of PySCIPOpt - use version 9.2.1\n",
+      "  self.model = pyscipopt.Model()\n"
+     ]
     }
    ],
    "source": [
-    "from ommx_pyscipopt_adapter import instance_to_model, model_to_solution\n",
+    "from ommx_pyscipopt_adapter import OMMXPySCIPOptAdapter\n",
     "\n",
-    "# Convert the instance to a format readable by SCIP\n",
-    "model = instance_to_model(instance)\n",
-    "# Solve the instance with SCIP\n",
-    "model.optimize()\n",
-    "# Retrieve the results obtained by SCIP\n",
-    "solution = model_to_solution(model, instance)\n",
+    "# Solve through SCIP and retrieve results as an ommx.v1.Solution\n",
+    "solution = OMMXPySCIPOptAdapter.solve(instance)\n",
     "\n",
     "print(f\"Optimal value of the objective function: {solution.objective}\")"
    ]
@@ -352,7 +356,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -366,9 +370,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/docs/ja/quickstart/scip.ipynb
+++ b/docs/ja/quickstart/scip.ipynb
@@ -212,14 +212,10 @@
     }
    ],
    "source": [
-    "from ommx_pyscipopt_adapter import instance_to_model, model_to_solution\n",
+    "from ommx_pyscipopt_adapter import OMMXPySCIPOptAdapter\n",
     "\n",
-    "# インスタンスをSCIPの読み取れる形に変換する\n",
-    "model = instance_to_model(instance)\n",
-    "# SCIPでインスタンスを解く\n",
-    "model.optimize()\n",
-    "# SCIPで得られた結果を取得する\n",
-    "solution = model_to_solution(model, instance)\n",
+    "# SCIPを介して問題を解き、ommx.v1.Solutionとして解を取得\n",
+    "solution = OMMXPySCIPOptAdapter.solve(instance)\n",
     "\n",
     "print(f\"目的関数の最適値: {solution.objective}\")"
    ]
@@ -352,7 +348,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -366,9 +362,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ requires-python = ">=3.9, <3.12" # jijmodeling does not support Python 3.12 yet
 dependencies = [
   "jijmodeling >= 1.10.0, < 1.11.0",
   "jijmodeling-transpiler>=0.6.15",
-  "ommx >= 1.4.1, < 2.0.0",
-  "ommx-pyscipopt-adapter >= 1.4.2, < 2.0.0",
+  "ommx >= 1.8.2, < 2.0.0",
+  "ommx-pyscipopt-adapter >= 1.8.2, < 2.0.0",
   "openjij>=0.9.2",
   "pytest>=8.3.3",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,8 @@ exceptiongroup==1.2.2
     # via pytest
 idna==3.10
     # via requests
+importlib-metadata==8.6.1
+    # via typeguard
 iniconfig==2.0.0
     # via pytest
 jij-cimod==1.6.2
@@ -52,12 +54,12 @@ numpy==1.26.4
     #   pyarrow
     #   pyqubo
     #   scipy
-ommx==1.5.1
+ommx==1.8.2
     # via
     #   jijmodeling-tutorial (pyproject.toml)
     #   jijmodeling
     #   ommx-pyscipopt-adapter
-ommx-pyscipopt-adapter==1.4.2
+ommx-pyscipopt-adapter==1.8.2
     # via jijmodeling-tutorial (pyproject.toml)
 openjij==0.9.2
     # via jijmodeling-tutorial (pyproject.toml)
@@ -120,3 +122,5 @@ urllib3==2.2.3
     # via requests
 wrapt==1.16.0
     # via deprecated
+zipp==3.21.0
+    # via importlib-metadata

--- a/uv.lock
+++ b/uv.lock
@@ -209,7 +209,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -470,7 +470,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "platform_system == 'Darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython", version = "8.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -667,8 +667,8 @@ dev = [
 requires-dist = [
     { name = "jijmodeling", specifier = ">=1.10.0,<1.11.0" },
     { name = "jijmodeling-transpiler", specifier = ">=0.6.15" },
-    { name = "ommx", specifier = ">=1.4.1,<2.0.0" },
-    { name = "ommx-pyscipopt-adapter", specifier = ">=1.4.2,<2.0.0" },
+    { name = "ommx", specifier = ">=1.8.2,<2.0.0" },
+    { name = "ommx-pyscipopt-adapter", specifier = ">=1.8.2,<2.0.0" },
     { name = "openjij", specifier = ">=0.9.2" },
     { name = "pytest", specifier = ">=8.3.3" },
 ]
@@ -1082,7 +1082,7 @@ wheels = [
 
 [[package]]
 name = "ommx"
-version = "1.5.1"
+version = "1.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -1093,26 +1093,26 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/7e/98b7f167c270ce6467ec6ef9c391dfde3e1805220a46b02c42e200088935/ommx-1.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ff314b2a159d9f86b19410a1ee87d670321b017cf0a0f38f07a3a6e87f3254cc", size = 2538995 },
-    { url = "https://files.pythonhosted.org/packages/91/aa/ef80601d93d9e85e1e3bf08c5b361c5452b85ae97526bf76827f1bfd2a35/ommx-1.5.1-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:bd74e3656f59e36fa86d8705ad786cd3e1db7da519b9bc24451258ce71229aa2", size = 2973856 },
-    { url = "https://files.pythonhosted.org/packages/14/52/9b47cd6e7e417d4842962c8338a8dc3aebc20c7d8d99cd283476bf5d13d9/ommx-1.5.1-cp310-none-win_amd64.whl", hash = "sha256:6e8d883eeb2e91ccc62d9b712dec6f1b2b2f20c1c93adc6db0a17cb5e9bcdf75", size = 2371527 },
-    { url = "https://files.pythonhosted.org/packages/63/4d/821b8fdcf36176cef68069796aa25800b408ffd17d83e010f0a410ff5813/ommx-1.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:6265783deb9a6f54bfc1db78b6ba0a28b4e062c3a1b0f870ecbf44c45df8b844", size = 2538005 },
-    { url = "https://files.pythonhosted.org/packages/37/4c/73e0e473937f72ee8181ed5b37b8d81a0a9595b6bdfe5c42a7db00b32c18/ommx-1.5.1-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:a685de34aee54e250422c8855aac735fac85e31a9f1009f1cc249f4ee1cd2982", size = 2975054 },
-    { url = "https://files.pythonhosted.org/packages/2e/ce/6da97d77927585f2588c19ee7fb20242c7f8eac3f52bfb9d5e4673beb0b1/ommx-1.5.1-cp311-none-win_amd64.whl", hash = "sha256:181f88715c4f478c48885093b4721a3d4cf7d4cfb2d79ae6e96e49516e291f9a", size = 2370906 },
-    { url = "https://files.pythonhosted.org/packages/09/f7/ebdb0790552f74ac724787a30cb857a95cdb30fb7fff44d7082628f10ee6/ommx-1.5.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9b3efe8fc2195cf9c0546df7a1cc6f6ca067e4da1096ecc92dd40f18f2e0e810", size = 2538895 },
-    { url = "https://files.pythonhosted.org/packages/8a/ec/5052fc6e53af003c155c87998c80f49bf0adef4399a3644c38761bc3cbfb/ommx-1.5.1-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:f14df51c8e15b549fe889451a8b9ce10627b9a835bc8962eeaa530e12929fbf2", size = 2973650 },
-    { url = "https://files.pythonhosted.org/packages/90/b2/f58e2984a6ad2457c49e9e7e5d0b0f3986ff01a3e1f0bc1aac3ba9edd025/ommx-1.5.1-cp39-none-win_amd64.whl", hash = "sha256:5f597c93435218354c8ff6d9a25cddc24a5d1b1cb78f82fabd4d3221128a7f02", size = 2371775 },
+    { url = "https://files.pythonhosted.org/packages/72/cd/a073dec1af798a59d5ee238891120d52a51ec9800bffa9c64ee5309ac675/ommx-1.8.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2b2781d5ef5bbd5dab75f8d686c676e4bf7daf15fa084751f4e91b0b050e2c6a", size = 2773696 },
+    { url = "https://files.pythonhosted.org/packages/45/5e/c4a943e306a8acef1dcbef7d9de9334031f87dd4fcd3e4751af96b4fca17/ommx-1.8.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:bbd24a4f85d52255c2c54b1fba5b9b5267fcd945cb37b71f4287ec2b4be8a223", size = 3217330 },
+    { url = "https://files.pythonhosted.org/packages/65/f1/2d22c661457290db830a300ebb528da969b46b29d4d83bcb90c9a28b7dcb/ommx-1.8.2-cp310-cp310-win_amd64.whl", hash = "sha256:f2b9b5277e90cb1965deba6603d14d4da59f117f0c32809f1b994945fe8ad46d", size = 2563037 },
+    { url = "https://files.pythonhosted.org/packages/a0/07/d23bec78a0d96687c2f44427ea0987e9329c681e8f82b4d4bfa62d30b504/ommx-1.8.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ff04f48f9c86d4847bd638d7f24f9c952a552f8c8199eda3724209ef45cb680d", size = 2773735 },
+    { url = "https://files.pythonhosted.org/packages/7a/cf/f89d078b089db193e36e07b006f4e2037dc83d379833646613e9bd567608/ommx-1.8.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:5dc33c8a568d5531da805672aa9dca3a53173fb2d33a5a28ea035f39bc05e97b", size = 3217332 },
+    { url = "https://files.pythonhosted.org/packages/64/16/ea8a59a68d1b1907890e32a38e0e1094d15207e8568ac81ef5fbe5782685/ommx-1.8.2-cp311-cp311-win_amd64.whl", hash = "sha256:967e5cff11dacbd95f3ee1120cb0d9802a16f61ce2857d9a92dece620d90a806", size = 2563122 },
+    { url = "https://files.pythonhosted.org/packages/1e/64/2e88e3c79f0070eca443897e581c6d1ad51dbb892ead5008ec0b72c8b08e/ommx-1.8.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:44fe79cf5185e60a5795b3458db54e5f92ee2cf2ecf719942398ddc5a84c8049", size = 2774086 },
+    { url = "https://files.pythonhosted.org/packages/fd/22/3bb30b57921e4fc2886a98381783a83bf8812bf3d6fe710cdc2d6091f265/ommx-1.8.2-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:7d7524c7bb8af2c7aa943d988818b5f189af5469e0283ce3c4f0530de2d9224a", size = 3218111 },
+    { url = "https://files.pythonhosted.org/packages/ee/fe/6452724610a4e756e307304594672c1c668b07196ce27a3778021cb365d1/ommx-1.8.2-cp39-cp39-win_amd64.whl", hash = "sha256:a81e80281aa29f8398e5c5986436593153e9d9bcb92a9248968aa9ca1ce41c4c", size = 2563216 },
 ]
 
 [[package]]
 name = "ommx-pyscipopt-adapter"
-version = "1.4.2"
+version = "1.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ommx" },
     { name = "pyscipopt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/0d/f021b3c2f618b96d4ef8c80f03379e922542ee119c0055283fc4d64e7186/ommx_pyscipopt_adapter-1.4.2.tar.gz", hash = "sha256:34083170068ecca2a96549db77b32e6f1eb541c0bfbd3563e920aa0165f75f9e", size = 5706 }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/3d/a5b9df4e2c57930c0ff374f65d7ad7de3439b7a8bbeecd6cd95fd0783606/ommx_pyscipopt_adapter-1.8.2.tar.gz", hash = "sha256:5abc5232dc2fbc9e9829f608448017ebedec737b588012992545246818bf2d8a", size = 7115 }
 
 [[package]]
 name = "openjij"


### PR DESCRIPTION
Update the SCIP tutorials to use the newest version of OMMX and `ommx-pyscipopt-adapter`, matching the API change. Example now uses `OMMXPySCIPOptAdapter.solve`.