### PR TITLE
Disables timeout for jupyter-books

### DIFF
--- a/docs/en/_config.yml
+++ b/docs/en/_config.yml
@@ -9,6 +9,7 @@ logo: logo.png
 # See https://jupyterbook.org/content/execute.html
 execute:
   execute_notebooks: force
+  timeout: -1  # Disable timeout
 
 # Define the name of the latex output file for PDF builds
 latex:

--- a/docs/ja/_config.yml
+++ b/docs/ja/_config.yml
@@ -9,6 +9,7 @@ logo: logo.png
 # See https://jupyterbook.org/content/execute.html
 execute:
   execute_notebooks: force
+  timeout: -1  # Disable timeout
 
 # Define the name of the latex output file for PDF builds
 latex:


### PR DESCRIPTION
Recently, jupyter book CI workflows tend to fail with timeout errors after we have considerable amount of release nots (see, e.g. https://github.com/Jij-Inc/JijModeling-Tutorials/actions/runs/14302277049/job/40078931246).
This PR aims at fix that just by disabling timeout constraints.