### PR TITLE
Sets Jupyter Book timeout to 60secs

### DIFF
--- a/docs/en/_config.yml
+++ b/docs/en/_config.yml
@@ -9,7 +9,7 @@ logo: logo.png
 # See https://jupyterbook.org/content/execute.html
 execute:
   execute_notebooks: force
-  timeout: -1  # Disable timeout
+  timeout: 60
 
 # Define the name of the latex output file for PDF builds
 latex:

--- a/docs/ja/_config.yml
+++ b/docs/ja/_config.yml
@@ -9,7 +9,7 @@ logo: logo.png
 # See https://jupyterbook.org/content/execute.html
 execute:
   execute_notebooks: force
-  timeout: -1  # Disable timeout
+  timeout: 60
 
 # Define the name of the latex output file for PDF builds
 latex:


### PR DESCRIPTION
In the previous PR #37, we disabled timeout for Jupyter Book. This is too permissive, so we try to re-introduce timeout limit but relaxed from the default ones.