### PR TITLE
Exclude release notes from executing & update links

### DIFF
--- a/docs/en/_config.yml
+++ b/docs/en/_config.yml
@@ -10,6 +10,8 @@ logo: logo.png
 execute:
   execute_notebooks: force
   timeout: 60
+  exclude_patterns:
+    - 'releases/*'
 
 # Define the name of the latex output file for PDF builds
 latex:

--- a/docs/en/quickstart/openjij.ipynb
+++ b/docs/en/quickstart/openjij.ipynb
@@ -87,7 +87,7 @@
    "source": [
     "## Creating a Model\n",
     "\n",
-    "Let's see how to model a common [knapsack problem](https://www.documentation.jijzept.com/docs/tutorial/knapsack).\n",
+    "Let's see how to model a common [knapsack problem](https://jij-inc.github.io/JijZept-Tutorials/en/src/02_knapsack.html).\n",
     "\n",
     "The knapsack problem is about maximizing the value of items you can carry within a weight limit $W$ when you have $N$ items, each with a value and weight. Below, we represent whether to carry item $i$ with a binary variable $x_{i}$, the weight of item $i$ with $w_i$, and the value of item $i$ with $v_i$.\n",
     "\n",
@@ -249,7 +249,7 @@
    "metadata": {},
    "source": [
     ":::{hint}\n",
-    "The return value of `Interpreter.eval_problem` is an `ommx.v1.Instance` object. For more details about OMMX, please refer to [here](https://github.com/Jij-Inc/ommx).\n",
+    "The return value of `Interpreter.eval_problem` is an `ommx.v1.Instance` object. For more details about OMMX, please refer to [here](https://jij-inc.github.io/ommx/en/introduction.html).\n",
     ":::"
    ]
   },
@@ -302,8 +302,8 @@
    "source": [
     "## Next Steps\n",
     "\n",
-    "- [Examples](https://www.documentation.jijzept.com/docs/category/learn)\n",
-    "- [JijZept](https://www.documentation.jijzept.com/docs/jijzept/)\n",
+    "- [Examples](https://jij-inc.github.io/JijZept-Tutorials/en/)\n",
+    "- [JijZept](https://www.jijzept.com/en/)\n",
     "- [OMMX](https://jij-inc.github.io/ommx/en/introduction.html)"
    ]
   }

--- a/docs/ja/_config.yml
+++ b/docs/ja/_config.yml
@@ -10,6 +10,8 @@ logo: logo.png
 execute:
   execute_notebooks: force
   timeout: 60
+  exclude_patterns:
+    - 'releases/*'
 
 # Define the name of the latex output file for PDF builds
 latex:

--- a/docs/ja/quickstart/openjij.ipynb
+++ b/docs/ja/quickstart/openjij.ipynb
@@ -87,7 +87,7 @@
    "source": [
     "## モデルの作成\n",
     "\n",
-    "一般的な[ナップサック問題](https://www.documentation.jijzept.com/docs/tutorial/knapsack)をどのようにモデル化するか見てみましょう。\n",
+    "一般的な[ナップサック問題](https://jij-inc.github.io/JijZept-Tutorials/ja/src/02_knapsack.html)をどのようにモデル化するか見てみましょう。\n",
     "\n",
     "ナップサック問題とは、それぞれ価値と重量が設定された$N$個のアイテムがあるとき、重量制限$W$の範囲内で持ち帰れるアイテムの価値を最大化する問題です。以下では、アイテム$i$を持ち帰るかどうかをバイナリ変数$x_{i}$で表現し、アイテム$i$の重量を$w_i$、アイテム$i$の価値を$v_i$で表現するものとします。\n",
     "\n",
@@ -251,7 +251,7 @@
    "metadata": {},
    "source": [
     ":::{hint}\n",
-    "`Interpreter.eval_problem` の返却値は `ommx.v1.Instance` オブジェクトです。OMMXについて詳しく知りたい場合は[こちら](https://github.com/Jij-Inc/ommx)を参照してください。\n",
+    "`Interpreter.eval_problem` の返却値は `ommx.v1.Instance` オブジェクトです。OMMXについて詳しく知りたい場合は[こちら](https://jij-inc.github.io/ommx/ja/introduction.html)を参照してください。\n",
     ":::"
    ]
   },
@@ -304,17 +304,10 @@
    "source": [
     "## 次のステップ\n",
     "\n",
-    "- [Examples](https://www.documentation.jijzept.com/docs/category/learn)\n",
-    "- [JijZept](https://www.documentation.jijzept.com/docs/jijzept/)\n",
-    "- [OMMX](https://jij-inc.github.io/ommx/en/introduction.html)"
+    "- [Examples](https://jij-inc.github.io/JijZept-Tutorials/ja/)\n",
+    "- [JijZept](https://www.jijzept.com/ja/)\n",
+    "- [OMMX](https://jij-inc.github.io/ommx/ja/introduction.html)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
- Excludes release notes directory from being executed to avoid problems with future updates
- Updates links in OpenJij quickstart tutorial