### PR TITLE
リリースノートを追加するTaskの追加

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -66,3 +66,11 @@ tasks:
     cmds:
       - task: build_book_en_all
       - task: open_book_en
+
+  create_release_note:
+    desc: Create release notes for the specified version
+    cmds:
+      - cp ./docs/ja/releases/template.ipynb ./docs/ja/releases/jijmodeling-{{.CLI_ARGS}}.ipynb
+      - cp ./docs/en/releases/template.ipynb ./docs/en/releases/jijmodeling-{{.CLI_ARGS}}.ipynb
+      - 'yq -i ''.parts[-1].chapters |= [{"file": "releases/jijmodeling-{{.CLI_ARGS}}"}] + .'' docs/ja/_toc.yml'
+      - 'yq -i ''.parts[-1].chapters |= [{"file": "releases/jijmodeling-{{.CLI_ARGS}}"}] + .'' docs/en/_toc.yml'


### PR DESCRIPTION
# 仕様
`task create_release_note -- x.y.z` を実行すると `docs/{en or ja}/releases/jijmodeling-x.y.z.ipynb` が追加され、JupyterBookのtocにも反映されます。