### PR TITLE
Add the links to typical problems

### DIFF
--- a/docs/en/_toc.yml
+++ b/docs/en/_toc.yml
@@ -27,10 +27,12 @@ parts:
       - file: advanced/serialize
   - caption: Reference
     chapters:
-      - url: https://jij-inc-jijmodeling.readthedocs-hosted.com/en/
-        title: jijmodeling API Reference
       - file: references/cheat_sheet
       - file: references/migration_guide_to_jijmodeling2
+      - url: https://jij-inc-jijmodeling.readthedocs-hosted.com/en/
+        title: JijModeling API Reference
+      - url: https://jij-inc-jijzept-tutorials-en.readthedocs-hosted.com/en/
+        title: Typical Problems
   - caption: Release Note
     chapters:
       - file: releases/jijmodeling-2.3.2

--- a/docs/ja/_toc.yml
+++ b/docs/ja/_toc.yml
@@ -28,10 +28,12 @@ parts:
       - file: advanced/serialize
   - caption: Reference
     chapters:
-      - url: https://jij-inc-jijmodeling.readthedocs-hosted.com/en/
-        title: jijmodeling API Reference
       - file: references/cheat_sheet
       - file: references/migration_guide_to_jijmodeling2
+      - url: https://jij-inc-jijmodeling.readthedocs-hosted.com/en/
+        title: JijModeling API Reference
+      - url: https://jij-inc-jijzept-tutorials-ja.readthedocs-hosted.com/ja/
+        title: 典型問題集
   - caption: Release Notes
     chapters:
       - file: releases/jijmodeling-2.3.2


### PR DESCRIPTION
# 変更点
- [典型問題集](https://jij-inc-jijzept-tutorials-ja.readthedocs-hosted.com/ja/latest/)へのリンクをサイドバーに追加しました
   - JijModelingによる定式化の具体例を見たい人が一定数存在するため、そのような人たちが典型問題集へ辿り着きやすくなる動線を整備する狙いがあります