### PR TITLE
Integrate api reference in ReadTheDocs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,91 +1,11 @@
 name: GitHub Pages
 
 on:
-  push:
-    branches:
-      - jijmodeling1
-  pull_request:
-    branches:
-      - jijmodeling1
   workflow_dispatch:
 
 jobs:
-  book:
-    strategy:
-      matrix:
-        lang:
-          - ja
-          - en
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          python-version: 3.11
-
-      - name: Set up Python and dependencies
-        run: |
-          uv sync --extra dev
-
-      - name: Build the book
-        env:
-          GA4_TRACKING_ID: ${{ secrets.GA4_TRACKING_ID }}
-        run: |
-          # Replace GA4_TRACKING_ID placeholder with actual value from secrets
-          # Using | as delimiter to avoid issues with / in the GA4 ID
-          sed -i "s|GA4_TRACKING_ID|${GA4_TRACKING_ID}|g" docs/${{ matrix.lang }}/_config.yml
-
-          # Build the book
-          uv run jupyter-book build docs/${{ matrix.lang }}
-          ERROR_LOGS=$(find docs/${{ matrix.lang }}/_build -type f -name "*.err.log")
-          if [ -n "$ERROR_LOGS" ]; then while IFS= read -r log; do echo "[ERROR LOG] $log" && cat "$log"; done <<< "$ERROR_LOGS" && exit 1; fi
-
-      - name: Upload HTML
-        uses: actions/upload-artifact@v4
-        with:
-          name: docs-${{ matrix.lang }}
-          path: ./docs/${{ matrix.lang }}/_build/html
-          retention-days: 30
-
-  package:
-    needs: book
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: API reference
-        run: |
-          mkdir -p package
-          mv apis package
-
-      - name: Setup redirect
-        run: mv docs/redirect/* package/
-
-      - name: Download HTML of docs
-        uses: actions/download-artifact@v4
-        with:
-          name: docs-ja
-          path: ./package/ja
-
-      - name: Download HTML of en
-        uses: actions/download-artifact@v4
-        with:
-          name: docs-en
-          path: ./package/en
-
-      - name: Upload Docs Package
-        uses: actions/upload-artifact@v4
-        with:
-          name: package
-          path: ./package
-          retention-days: 30
-
   deploy:
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pages: write
@@ -95,18 +15,13 @@ jobs:
       group: "pages"
       cancel-in-progress: false
 
-    if: github.ref == 'refs/heads/main'
-    needs: package
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+
     steps:
-      - name: Download Docs Package
-        uses: actions/download-artifact@v4
-        with:
-          name: package
-          path: .
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
@@ -114,7 +29,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: "."
+          path: ./docs/redirect
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tutorial and Learning materials for JijModeling 
 
-[![Book-EN](https://img.shields.io/badge/Book-English-blue)](https://jij-inc.github.io/JijModeling-Tutorials/en)
-[![Book-JA](https://img.shields.io/badge/Book-日本語-blue)](https://jij-inc.github.io/JijModeling-Tutorials/ja)
+[![Book-EN](https://img.shields.io/badge/Book-English-blue)](https://jij-inc-jijmodeling-tutorials-en.readthedocs-hosted.com/en/jijmodeling1/introduction.html)
+[![Book-JA](https://img.shields.io/badge/Book-日本語-blue)](https://jij-inc-jijmodeling-tutorials-ja.readthedocs-hosted.com/ja/jijmodeling1/introduction.html)
 [![Discord-EN](https://img.shields.io/badge/Discord-English-default?logo=Discord)](https://discord.gg/bcP4g4ar6J)
 [![Discord-JP](https://img.shields.io/badge/Discord-日本語-default?logo=Discord)](https://discord.gg/34WkHwvY3Y)
 
@@ -18,8 +18,8 @@ There are Jupyter Books in both Japanese and English.
 
 | Language | Path | GitHub Pages |
 |----------|------|--------------|
-| English  | [docs/en](./docs/en) | [![Book-EN](https://img.shields.io/badge/Book-English-blue)](https://jij-inc.github.io/JijModeling-Tutorials/en) |
-| 日本語   | [docs/ja](./docs/ja) | [![Book-JA](https://img.shields.io/badge/Book-日本語-blue)](https://jij-inc.github.io/JijModeling-Tutorials/ja) |
+| English  | [docs/en](./docs/en) | [![Book-EN](https://img.shields.io/badge/Book-English-blue)](https://jij-inc-jijmodeling-tutorials-en.readthedocs-hosted.com/en/jijmodeling1/introduction.html) |
+| 日本語   | [docs/ja](./docs/ja) | [![Book-JA](https://img.shields.io/badge/Book-日本語-blue)](https://jij-inc-jijmodeling-tutorials-ja.readthedocs-hosted.com/ja/jijmodeling1/introduction.html) |
 
 Each notebook is managed independently and translated manually.
 

--- a/docs/en/.readthedocs.yaml
+++ b/docs/en/.readthedocs.yaml
@@ -5,16 +5,12 @@ build:
   tools:
     python: "3.11"
   jobs:
-    pre_build:
-      # Generate the Sphinx configuration for this Jupyter Book so it builds.
-      - "jupyter-book config sphinx docs/en/"
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-      - dev
-
-sphinx:
-  configuration: docs/en/conf.py
+    install:
+      - python -m pip install --upgrade --no-cache-dir pip setuptools 
+      - python -m pip install --upgrade --no-cache-dir sphinx
+      - python -m pip install --upgrade --upgrade-strategy only-if-needed --no-cache-dir ".[dev]" 
+    build:
+      html:
+        - jupyter-book build docs/en --all
+        - cp -r docs/en/_build/html/* "${READTHEDOCS_OUTPUT}/html"
+        - cp -r apis "${READTHEDOCS_OUTPUT}/html/references/"

--- a/docs/en/.readthedocs.yaml
+++ b/docs/en/.readthedocs.yaml
@@ -6,6 +6,7 @@ build:
     python: "3.11"
   jobs:
     install:
+      - python -mvirtualenv $READTHEDOCS_VIRTUALENV_PATH
       - python -m pip install --upgrade --no-cache-dir pip setuptools 
       - python -m pip install --upgrade --no-cache-dir sphinx
       - python -m pip install --upgrade --upgrade-strategy only-if-needed --no-cache-dir ".[dev]" 

--- a/docs/en/.readthedocs.yaml
+++ b/docs/en/.readthedocs.yaml
@@ -13,5 +13,6 @@ build:
     build:
       html:
         - jupyter-book build docs/en --all
+        - mkdir -p "${READTHEDOCS_OUTPUT}/html/references/"
         - cp -r docs/en/_build/html/* "${READTHEDOCS_OUTPUT}/html"
         - cp -r apis "${READTHEDOCS_OUTPUT}/html/references/"

--- a/docs/en/_toc.yml
+++ b/docs/en/_toc.yml
@@ -6,7 +6,7 @@ root: introduction
 parts:
   - caption: Switch Language
     chapters:
-      - url: https://jij-inc.github.io/JijModeling-Tutorials/ja/
+      - url: https://jij-inc-jijmodeling-tutorials-ja.readthedocs-hosted.com/ja/jijmodeling1/introduction.html
         title: 日本語
   - caption: Quick Start
     chapters:
@@ -20,8 +20,8 @@ parts:
       - file: tutorials/constraint_and_penalty
   - caption: Reference
     chapters:
-      - url: https://jij-inc.github.io/JijModeling-Tutorials/apis/jijmodeling.html
-        title: jijmodeling API Reference
+      - title: JijModeling API Reference
+        url: https://jij-inc-jijmodeling-tutorials-en.readthedocs-hosted.com/en/jijmodeling1/references/apis/index.html
       - file: references/tips
       - file: references/cheat_sheet
   - caption: Release Note

--- a/docs/ja/.readthedocs.yaml
+++ b/docs/ja/.readthedocs.yaml
@@ -13,5 +13,6 @@ build:
     build:
       html:
         - jupyter-book build docs/ja --all
+        - mkdir -p "${READTHEDOCS_OUTPUT}/html/references/"
         - cp -r docs/ja/_build/html/* "${READTHEDOCS_OUTPUT}/html"
         - cp -r apis "${READTHEDOCS_OUTPUT}/html/references/"

--- a/docs/ja/.readthedocs.yaml
+++ b/docs/ja/.readthedocs.yaml
@@ -5,16 +5,12 @@ build:
   tools:
     python: "3.11"
   jobs:
-    pre_build:
-      # Generate the Sphinx configuration for this Jupyter Book so it builds.
-      - "jupyter-book config sphinx docs/ja/"
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-      - dev
-
-sphinx:
-  configuration: docs/ja/conf.py
+    install:
+      - python -m pip install --upgrade --no-cache-dir pip setuptools 
+      - python -m pip install --upgrade --no-cache-dir sphinx
+      - python -m pip install --upgrade --upgrade-strategy only-if-needed --no-cache-dir ".[dev]" 
+    build:
+      html:
+        - jupyter-book build docs/ja --all
+        - cp -r docs/ja/_build/html/* "${READTHEDOCS_OUTPUT}/html"
+        - cp -r apis "${READTHEDOCS_OUTPUT}/html/references/"

--- a/docs/ja/.readthedocs.yaml
+++ b/docs/ja/.readthedocs.yaml
@@ -6,6 +6,7 @@ build:
     python: "3.11"
   jobs:
     install:
+      - python -mvirtualenv $READTHEDOCS_VIRTUALENV_PATH
       - python -m pip install --upgrade --no-cache-dir pip setuptools 
       - python -m pip install --upgrade --no-cache-dir sphinx
       - python -m pip install --upgrade --upgrade-strategy only-if-needed --no-cache-dir ".[dev]" 

--- a/docs/ja/_toc.yml
+++ b/docs/ja/_toc.yml
@@ -6,7 +6,7 @@ root: introduction
 parts:
   - caption: Switch Language
     chapters:
-      - url: https://jij-inc.github.io/JijModeling-Tutorials/en/
+      - url: https://jij-inc-jijmodeling-tutorials-en.readthedocs-hosted.com/en/jijmodeling1/introduction.html
         title: English
   - caption: クイックスタート
     chapters:
@@ -20,8 +20,8 @@ parts:
       - file: tutorials/constraint_and_penalty
   - caption: リファレンス
     chapters:
-      - url: https://jij-inc.github.io/JijModeling-Tutorials/apis/jijmodeling.html
-        title: jijmodeling API Reference
+      - title: JijModeling API Reference
+        url: https://jij-inc-jijmodeling-tutorials-ja.readthedocs-hosted.com/ja/jijmodeling1/references/apis/index.html
       - file: references/tips
       - file: references/cheat_sheet
   - caption: リリースノート

--- a/docs/redirect/404.html
+++ b/docs/redirect/404.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting...</title>
+  <meta http-equiv="refresh" content="0;URL='https://jij-inc-jijmodeling-tutorials-en.readthedocs-hosted.com/en/latest/introduction.html'">
+</head>
+<body>
+  The JijModeling documentation site has moved.
+  If you are not redirected automatically, please click <a href="https://jij-inc-jijmodeling-tutorials-en.readthedocs-hosted.com/en/latest/introduction.html">here</a>.
+</body>
+</html>

--- a/docs/redirect/getting_started.html
+++ b/docs/redirect/getting_started.html
@@ -1,1 +1,0 @@
-<meta http-equiv="Refresh" content="0; url=ja/getting_started.html" />

--- a/docs/redirect/index.html
+++ b/docs/redirect/index.html
@@ -1,1 +1,0 @@
-<meta http-equiv="Refresh" content="0; url=ja/index.html" />

--- a/docs/redirect/introduction.html
+++ b/docs/redirect/introduction.html
@@ -1,1 +1,0 @@
-<meta http-equiv="Refresh" content="0; url=ja/introduction.html" />

--- a/docs/redirect/quickstart/openjij.html
+++ b/docs/redirect/quickstart/openjij.html
@@ -1,1 +1,0 @@
-<meta http-equiv="Refresh" content="0; url=../ja/quickstart/openjij.html" />

--- a/docs/redirect/quickstart/scip.html
+++ b/docs/redirect/quickstart/scip.html
@@ -1,1 +1,0 @@
-<meta http-equiv="Refresh" content="0; url=../ja/quickstart/scip.html" />

--- a/docs/redirect/references/cheat_sheet.html
+++ b/docs/redirect/references/cheat_sheet.html
@@ -1,1 +1,0 @@
-<meta http-equiv="Refresh" content="0; url=../ja/references/cheat_sheet.html" />

--- a/docs/redirect/references/tips.html
+++ b/docs/redirect/references/tips.html
@@ -1,1 +1,0 @@
-<meta http-equiv="Refresh" content="0; url=../ja/references/tips.html" />

--- a/docs/redirect/releases/jijmodeling-1.10.0.html
+++ b/docs/redirect/releases/jijmodeling-1.10.0.html
@@ -1,1 +1,0 @@
-<meta http-equiv="Refresh" content="0; url=../ja/releases/jijmodeling-1.10.0.html" />

--- a/docs/redirect/releases/jijmodeling-1.10.1.html
+++ b/docs/redirect/releases/jijmodeling-1.10.1.html
@@ -1,1 +1,0 @@
-<meta http-equiv="Refresh" content="0; url=../ja/releases/jijmodeling-1.10.1.html" />

--- a/docs/redirect/releases/jijmodeling-1.11.0.html
+++ b/docs/redirect/releases/jijmodeling-1.11.0.html
@@ -1,1 +1,0 @@
-<meta http-equiv="Refresh" content="0; url=../ja/releases/jijmodeling-1.11.0.html" />

--- a/docs/redirect/releases/jijmodeling-1.8.0.html
+++ b/docs/redirect/releases/jijmodeling-1.8.0.html
@@ -1,1 +1,0 @@
-<meta http-equiv="Refresh" content="0; url=../ja/releases/jijmodeling-1.8.0.html" />

--- a/docs/redirect/releases/jijmodeling-1.9.0.html
+++ b/docs/redirect/releases/jijmodeling-1.9.0.html
@@ -1,1 +1,0 @@
-<meta http-equiv="Refresh" content="0; url=../ja/releases/jijmodeling-1.9.0.html" />

--- a/docs/redirect/tutorials/constraint_and_penalty.html
+++ b/docs/redirect/tutorials/constraint_and_penalty.html
@@ -1,1 +1,0 @@
-<meta http-equiv="Refresh" content="0; url=../ja/tutorials/constraint_and_penalty.html" />

--- a/docs/redirect/tutorials/creating_models.html
+++ b/docs/redirect/tutorials/creating_models.html
@@ -1,1 +1,0 @@
-<meta http-equiv="Refresh" content="0; url=../ja/tutorials/creating_models.html" />

--- a/docs/redirect/tutorials/expressions.html
+++ b/docs/redirect/tutorials/expressions.html
@@ -1,1 +1,0 @@
-<meta http-equiv="Refresh" content="0; url=../ja/tutorials/expressions.html" />

--- a/docs/redirect/tutorials/types_and_bounds.html
+++ b/docs/redirect/tutorials/types_and_bounds.html
@@ -1,1 +1,0 @@
-<meta http-equiv="Refresh" content="0; url=../ja/tutorials/types_and_bounds.html" />


### PR DESCRIPTION
# 変更点
- ReadTheDocsのビルドプロセスを変更し、JupyterBookのビルド成果物と `/apis` ディレクトリを統合してデプロイする形に変更しました
  - これにより、APIリファレンスもReadTheDocsにデプロイされる形になります
    - 本PRに紐づくReadTheDocsのAPIリファレンスは以下のURLから確認できます
      - EN: https://jij-inc-jijmodeling-tutorials-en--144.com.readthedocs.build/en/144/references/apis/jijmodeling.html
      - JA: https://jij-inc-jijmodeling-tutorials-ja--144.com.readthedocs.build/ja/144/references/apis/jijmodeling.html
    - 注意点: 本PRに紐づくReadTheDocsではJupyterBookのサイドバーにあるAPIリファレンスへのリンクは機能していません。 これは、`jijmodeling1` ブランチへのマージによって解決される予定です
 - GitHubPagesへのドキュメントデプロイのワークフロー `docs.yml` を変更し、`404.htm` を置くだけの形に変更しました
   - `/redirect` ディレクトリの不要なHTMLを削除し、代わりに、 `404.html` （GitHubPagesが404を返す場合に表示されるカスタムHTML）を置く形に変更しました
   - `docs.yml` はWorkflowDispatchのみでトリガーする形に変更しました。定期的なデプロイが不要であるため、手動実行で十分であると考えたからです
     - 既にGitHubPagesには `404.html` がデプロイ済みです: https://jij-inc.github.io/JijModeling-Tutorials/en