### PR TITLE
Add unreleased release note for the jm.range computed-bounds fix

### DIFF
--- a/docs/en/releases/unreleased.ipynb
+++ b/docs/en/releases/unreleased.ipynb
@@ -29,10 +29,10 @@
    "id": "cc6ffcae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T02:17:09.106626Z",
-     "iopub.status.busy": "2026-07-22T02:17:09.106451Z",
-     "iopub.status.idle": "2026-07-22T02:17:09.206846Z",
-     "shell.execute_reply": "2026-07-22T02:17:09.206139Z"
+     "iopub.execute_input": "2026-07-22T09:36:13.616422Z",
+     "iopub.status.busy": "2026-07-22T09:36:13.616301Z",
+     "iopub.status.idle": "2026-07-22T09:36:13.717063Z",
+     "shell.execute_reply": "2026-07-22T09:36:13.716409Z"
     }
    },
    "outputs": [
@@ -42,15 +42,15 @@
      "text": [
       "Traceback (most recent last):\n",
       "    while checking if expression `x[W]` has type `float!`,\n",
-      "        defined at File \"/tmp/ipykernel_759427/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_1343735/2363250674.py\", line 11, col 20-24\n",
       "    while inferring the type of expression `x[W]`,\n",
-      "        defined at File \"/tmp/ipykernel_759427/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_1343735/2363250674.py\", line 11, col 20-24\n",
       "    while inferring the type of expression `x[W]`,\n",
-      "        defined at File \"/tmp/ipykernel_759427/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_1343735/2363250674.py\", line 11, col 20-24\n",
       "    while checking if type `Array[N; binary!]` can be subscripted with (W): (float),\n",
-      "        defined at File \"/tmp/ipykernel_759427/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_1343735/2363250674.py\", line 11, col 20-24\n",
       "\n",
-      "File \"/tmp/ipykernel_759427/2363250674.py\", line 11, col 20-24:\n",
+      "File \"/tmp/ipykernel_1343735/2363250674.py\", line 11, col 20-24:\n",
       "\n",
       "    11  |          problem += x[W] # Error!\n",
       "                              ^^^^\n",
@@ -58,7 +58,7 @@
       "\u001b[1;31merror[E-TE0004]\u001b[0m Could not match actual type `float` with expected `natural`\n",
       "\n",
       "Mismatched on expression: `W`\n",
-      "    defined at File \"/tmp/ipykernel_759427/2363250674.py\", line 11, col 20-24\n",
+      "    defined at File \"/tmp/ipykernel_1343735/2363250674.py\", line 11, col 20-24\n",
       "\n",
       "Hint: You can read the description and possible fix at https://jij-inc-jijmodeling.readthedocs-hosted.com/en/stable/error_codes/error/E-TE0004.html\n"
      ]
@@ -98,10 +98,10 @@
    "id": "69b81dd7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T02:17:09.209030Z",
-     "iopub.status.busy": "2026-07-22T02:17:09.208879Z",
-     "iopub.status.idle": "2026-07-22T02:17:11.198529Z",
-     "shell.execute_reply": "2026-07-22T02:17:11.197714Z"
+     "iopub.execute_input": "2026-07-22T09:36:13.719688Z",
+     "iopub.status.busy": "2026-07-22T09:36:13.719525Z",
+     "iopub.status.idle": "2026-07-22T09:36:15.611933Z",
+     "shell.execute_reply": "2026-07-22T09:36:15.611128Z"
     }
    },
    "outputs": [
@@ -158,11 +158,75 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2476eb2d",
    "metadata": {},
    "source": [
-    "### Bugfix 1\n",
+    "### Fixed an internal error for `jm.range` with computed bounds\n",
     "\n",
+    "Previously, passing a computed expression such as `N - 1` as a bound of `jm.range` caused an internal error ([E-CE0007](https://jij-inc-jijmodeling.readthedocs-hosted.com/en/v2.6.0/error_codes/error/E-CE0007.html)) when the model was evaluated, showing a message that asked users to report it as a bug in JijModeling. This affected not only `domain=` of constraints but every place where `jm.range` is evaluated, such as the index set of a summation (ranges with literal or bare-placeholder bounds like `jm.range(N)` were unaffected).\n",
     "\n",
+    "With this fix, ranges whose bounds contain expressions now evaluate correctly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "9bcf3dec",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T09:36:15.613602Z",
+     "iopub.status.busy": "2026-07-22T09:36:15.613444Z",
+     "iopub.status.idle": "2026-07-22T09:36:18.706486Z",
+     "shell.execute_reply": "2026-07-22T09:36:18.705721Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\begin{array}{rl}\n",
+       "\\text{Problem}\\colon &\\text{RangeWithComputedBounds}\\\\\\displaystyle \\min &\\displaystyle \\sum _{i\\in \\mathop{\\mathtt{range}}\\left(N-1\\right)}{{x}_{i}}\\\\&\\\\\\text{s.t.}&\\\\&\\begin{aligned}\n",
+       "\\text{fix}&\\quad \\displaystyle {x}_{i}=0\\quad \\forall i\\;\\text{s.t.}\\;i\\in \\mathop{\\mathtt{range}}\\left(N-1\\right)\\end{aligned}\n",
+       "\\\\&\\\\\\text{where}&\\\\&\\text{Decision Variables:}\\\\&\\qquad \\begin{alignedat}{2}{x}_{i}&\\in \\left\\{0,1\\right\\}&\\qquad &\\text{a }1\\text{-dim array of }\\text{binary}\\text{ decision variables}\\\\&\\forall i\\in \\left\\{0,\\ldots ,N-1\\right\\}&&\\\\\\end{alignedat}\\\\&\\\\&\\text{Placeholders:}\\\\&\\qquad \\begin{alignedat}{2}N&\\in \\mathbb{N}&\\qquad &\\text{a scalar placeholder in }\\mathbb{N}\\\\\\end{alignedat}\\end{array}\n",
+       "$$"
+      ],
+      "text/plain": [
+       "Problem(name=\"RangeWithComputedBounds\", sense=MINIMIZE, objective=sum(set(range(N - 1)).map(lambda (i: natural): x[i])), constraints={fix: [Constraint(name=\"fix\", lambda i: x[i] == 0, domain=range(N - 1)),],})"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Instance(raw=<builtins.Instance object at 0x64c3a1381420>, annotations={})"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import jijmodeling as jm\n",
+    "\n",
+    "@jm.Problem.define(\"RangeWithComputedBounds\")\n",
+    "def problem(problem: jm.DecoratedProblem):\n",
+    "    N = problem.Natural()\n",
+    "    x = problem.BinaryVar(shape=(N,))\n",
+    "    problem += jm.sum(x[i] for i in jm.range(N - 1))\n",
+    "    problem += problem.Constraint(\"fix\", lambda i: x[i] == 0, domain=jm.range(N - 1))\n",
+    "\n",
+    "display(problem)\n",
+    "\n",
+    "problem.eval({\"N\": 4})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Other Changes\n",
     "\n",
     "-"

--- a/docs/en/releases/unreleased.ipynb
+++ b/docs/en/releases/unreleased.ipynb
@@ -29,10 +29,10 @@
    "id": "cc6ffcae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T09:36:13.616422Z",
-     "iopub.status.busy": "2026-07-22T09:36:13.616301Z",
-     "iopub.status.idle": "2026-07-22T09:36:13.717063Z",
-     "shell.execute_reply": "2026-07-22T09:36:13.716409Z"
+     "iopub.execute_input": "2026-07-23T01:49:35.908360Z",
+     "iopub.status.busy": "2026-07-23T01:49:35.908197Z",
+     "iopub.status.idle": "2026-07-23T01:49:36.053034Z",
+     "shell.execute_reply": "2026-07-23T01:49:36.051442Z"
     }
    },
    "outputs": [
@@ -42,15 +42,15 @@
      "text": [
       "Traceback (most recent last):\n",
       "    while checking if expression `x[W]` has type `float!`,\n",
-      "        defined at File \"/tmp/ipykernel_1343735/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_1577398/2363250674.py\", line 11, col 20-24\n",
       "    while inferring the type of expression `x[W]`,\n",
-      "        defined at File \"/tmp/ipykernel_1343735/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_1577398/2363250674.py\", line 11, col 20-24\n",
       "    while inferring the type of expression `x[W]`,\n",
-      "        defined at File \"/tmp/ipykernel_1343735/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_1577398/2363250674.py\", line 11, col 20-24\n",
       "    while checking if type `Array[N; binary!]` can be subscripted with (W): (float),\n",
-      "        defined at File \"/tmp/ipykernel_1343735/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_1577398/2363250674.py\", line 11, col 20-24\n",
       "\n",
-      "File \"/tmp/ipykernel_1343735/2363250674.py\", line 11, col 20-24:\n",
+      "File \"/tmp/ipykernel_1577398/2363250674.py\", line 11, col 20-24:\n",
       "\n",
       "    11  |          problem += x[W] # Error!\n",
       "                              ^^^^\n",
@@ -58,7 +58,7 @@
       "\u001b[1;31merror[E-TE0004]\u001b[0m Could not match actual type `float` with expected `natural`\n",
       "\n",
       "Mismatched on expression: `W`\n",
-      "    defined at File \"/tmp/ipykernel_1343735/2363250674.py\", line 11, col 20-24\n",
+      "    defined at File \"/tmp/ipykernel_1577398/2363250674.py\", line 11, col 20-24\n",
       "\n",
       "Hint: You can read the description and possible fix at https://jij-inc-jijmodeling.readthedocs-hosted.com/en/stable/error_codes/error/E-TE0004.html\n"
      ]
@@ -98,10 +98,10 @@
    "id": "69b81dd7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T09:36:13.719688Z",
-     "iopub.status.busy": "2026-07-22T09:36:13.719525Z",
-     "iopub.status.idle": "2026-07-22T09:36:15.611933Z",
-     "shell.execute_reply": "2026-07-22T09:36:15.611128Z"
+     "iopub.execute_input": "2026-07-23T01:49:36.056078Z",
+     "iopub.status.busy": "2026-07-23T01:49:36.055865Z",
+     "iopub.status.idle": "2026-07-23T01:49:38.457315Z",
+     "shell.execute_reply": "2026-07-23T01:49:38.455946Z"
     }
    },
    "outputs": [
@@ -161,11 +161,11 @@
    "id": "2476eb2d",
    "metadata": {},
    "source": [
-    "### Fixed an internal error for `jm.range` with computed bounds\n",
+    "### Fixed an internal error for `jm.range` with computed arguments\n",
     "\n",
-    "Previously, passing a computed expression such as `N - 1` as a bound of `jm.range` caused an internal error ([E-CE0007](https://jij-inc-jijmodeling.readthedocs-hosted.com/en/v2.6.0/error_codes/error/E-CE0007.html)) when the model was evaluated, showing a message that asked users to report it as a bug in JijModeling. This affected not only `domain=` of constraints but every place where `jm.range` is evaluated, such as the index set of a summation (ranges with literal or bare-placeholder bounds like `jm.range(N)` were unaffected).\n",
+    "Previously, passing a computed expression such as `N - 1` as a argument of `jm.range` caused an internal error ([E-CE0007](https://jij-inc-jijmodeling.readthedocs-hosted.com/en/v2.6.0/error_codes/error/E-CE0007.html)) when the model was evaluated, showing a message that asked users to report it as a bug in JijModeling. This affected not only `domain=` of constraints but every place where `jm.range` is evaluated, such as the index set of a summation (ranges with literal or bare-placeholder arguments like `jm.range(N)` were unaffected).\n",
     "\n",
-    "With this fix, ranges whose bounds contain expressions now evaluate correctly."
+    "With this fix, ranges whose arguments contain expressions now evaluate correctly."
    ]
   },
   {
@@ -174,10 +174,10 @@
    "id": "9bcf3dec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T09:36:15.613602Z",
-     "iopub.status.busy": "2026-07-22T09:36:15.613444Z",
-     "iopub.status.idle": "2026-07-22T09:36:18.706486Z",
-     "shell.execute_reply": "2026-07-22T09:36:18.705721Z"
+     "iopub.execute_input": "2026-07-23T01:49:38.460346Z",
+     "iopub.status.busy": "2026-07-23T01:49:38.460123Z",
+     "iopub.status.idle": "2026-07-23T01:49:43.470418Z",
+     "shell.execute_reply": "2026-07-23T01:49:43.469624Z"
     }
    },
    "outputs": [
@@ -200,7 +200,7 @@
     {
      "data": {
       "text/plain": [
-       "Instance(raw=<builtins.Instance object at 0x64c3a1381420>, annotations={})"
+       "Instance(raw=<builtins.Instance object at 0x62ead482c0b0>, annotations={})"
       ]
      },
      "execution_count": 3,

--- a/docs/ja/releases/unreleased.ipynb
+++ b/docs/ja/releases/unreleased.ipynb
@@ -29,10 +29,10 @@
    "id": "8b31ba06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T02:17:12.138365Z",
-     "iopub.status.busy": "2026-07-22T02:17:12.138214Z",
-     "iopub.status.idle": "2026-07-22T02:17:12.237280Z",
-     "shell.execute_reply": "2026-07-22T02:17:12.236598Z"
+     "iopub.execute_input": "2026-07-22T09:36:19.730932Z",
+     "iopub.status.busy": "2026-07-22T09:36:19.730785Z",
+     "iopub.status.idle": "2026-07-22T09:36:19.823830Z",
+     "shell.execute_reply": "2026-07-22T09:36:19.823127Z"
     }
    },
    "outputs": [
@@ -42,15 +42,15 @@
      "text": [
       "Traceback (most recent last):\n",
       "    while checking if expression `x[W]` has type `float!`,\n",
-      "        defined at File \"/tmp/ipykernel_759485/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_1343873/2363250674.py\", line 11, col 20-24\n",
       "    while inferring the type of expression `x[W]`,\n",
-      "        defined at File \"/tmp/ipykernel_759485/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_1343873/2363250674.py\", line 11, col 20-24\n",
       "    while inferring the type of expression `x[W]`,\n",
-      "        defined at File \"/tmp/ipykernel_759485/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_1343873/2363250674.py\", line 11, col 20-24\n",
       "    while checking if type `Array[N; binary!]` can be subscripted with (W): (float),\n",
-      "        defined at File \"/tmp/ipykernel_759485/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_1343873/2363250674.py\", line 11, col 20-24\n",
       "\n",
-      "File \"/tmp/ipykernel_759485/2363250674.py\", line 11, col 20-24:\n",
+      "File \"/tmp/ipykernel_1343873/2363250674.py\", line 11, col 20-24:\n",
       "\n",
       "    11  |          problem += x[W] # Error!\n",
       "                              ^^^^\n",
@@ -58,7 +58,7 @@
       "\u001b[1;31merror[E-TE0004]\u001b[0m Could not match actual type `float` with expected `natural`\n",
       "\n",
       "Mismatched on expression: `W`\n",
-      "    defined at File \"/tmp/ipykernel_759485/2363250674.py\", line 11, col 20-24\n",
+      "    defined at File \"/tmp/ipykernel_1343873/2363250674.py\", line 11, col 20-24\n",
       "\n",
       "Hint: You can read the description and possible fix at https://jij-inc-jijmodeling.readthedocs-hosted.com/en/stable/error_codes/error/E-TE0004.html\n"
      ]
@@ -98,10 +98,10 @@
    "id": "46b7f69f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T02:17:12.239392Z",
-     "iopub.status.busy": "2026-07-22T02:17:12.239228Z",
-     "iopub.status.idle": "2026-07-22T02:17:14.272150Z",
-     "shell.execute_reply": "2026-07-22T02:17:14.271429Z"
+     "iopub.execute_input": "2026-07-22T09:36:19.825643Z",
+     "iopub.status.busy": "2026-07-22T09:36:19.825455Z",
+     "iopub.status.idle": "2026-07-22T09:36:21.740174Z",
+     "shell.execute_reply": "2026-07-22T09:36:21.739552Z"
     }
    },
    "outputs": [
@@ -158,11 +158,75 @@
   },
   {
    "cell_type": "markdown",
+   "id": "528ebd98",
    "metadata": {},
    "source": [
-    "### バグ修正1：\n",
+    "### 端点に式を含む `jm.range` が内部エラーになる問題を修正\n",
     "\n",
+    "これまで、`jm.range` の引数に `N - 1` のような計算式を渡すと、モデルの評価時に内部エラー（[E-CE0007](https://jij-inc-jijmodeling.readthedocs-hosted.com/en/v2.6.0/error_codes/error/E-CE0007.html)）が発生し、JijModeling 側のバグとして報告されていました。この問題は制約の `domain=` に限らず、総和の添字集合など `jm.range` を評価する全ての箇所で発生していました（リテラルや単独のプレースホルダーを端点とする `jm.range(N)` などは影響を受けません）。\n",
     "\n",
+    "今回の修正により、端点に式を含む range も正しく評価されるようになりました。"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "53a87203",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-22T09:36:21.742007Z",
+     "iopub.status.busy": "2026-07-22T09:36:21.741878Z",
+     "iopub.status.idle": "2026-07-22T09:36:25.579095Z",
+     "shell.execute_reply": "2026-07-22T09:36:25.578319Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$\\begin{array}{rl}\n",
+       "\\text{Problem}\\colon &\\text{RangeWithComputedBounds}\\\\\\displaystyle \\min &\\displaystyle \\sum _{i\\in \\mathop{\\mathtt{range}}\\left(N-1\\right)}{{x}_{i}}\\\\&\\\\\\text{s.t.}&\\\\&\\begin{aligned}\n",
+       "\\text{fix}&\\quad \\displaystyle {x}_{i}=0\\quad \\forall i\\;\\text{s.t.}\\;i\\in \\mathop{\\mathtt{range}}\\left(N-1\\right)\\end{aligned}\n",
+       "\\\\&\\\\\\text{where}&\\\\&\\text{Decision Variables:}\\\\&\\qquad \\begin{alignedat}{2}{x}_{i}&\\in \\left\\{0,1\\right\\}&\\qquad &\\text{a }1\\text{-dim array of }\\text{binary}\\text{ decision variables}\\\\&\\forall i\\in \\left\\{0,\\ldots ,N-1\\right\\}&&\\\\\\end{alignedat}\\\\&\\\\&\\text{Placeholders:}\\\\&\\qquad \\begin{alignedat}{2}N&\\in \\mathbb{N}&\\qquad &\\text{a scalar placeholder in }\\mathbb{N}\\\\\\end{alignedat}\\end{array}\n",
+       "$$"
+      ],
+      "text/plain": [
+       "Problem(name=\"RangeWithComputedBounds\", sense=MINIMIZE, objective=sum(set(range(N - 1)).map(lambda (i: natural): x[i])), constraints={fix: [Constraint(name=\"fix\", lambda i: x[i] == 0, domain=range(N - 1)),],})"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Instance(raw=<builtins.Instance object at 0x5ca4a8ca9080>, annotations={})"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import jijmodeling as jm\n",
+    "\n",
+    "@jm.Problem.define(\"RangeWithComputedBounds\")\n",
+    "def problem(problem: jm.DecoratedProblem):\n",
+    "    N = problem.Natural()\n",
+    "    x = problem.BinaryVar(shape=(N,))\n",
+    "    problem += jm.sum(x[i] for i in jm.range(N - 1))\n",
+    "    problem += problem.Constraint(\"fix\", lambda i: x[i] == 0, domain=jm.range(N - 1))\n",
+    "\n",
+    "display(problem)\n",
+    "\n",
+    "problem.eval({\"N\": 4})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## その他の変更\n",
     "\n",
     "-"

--- a/docs/ja/releases/unreleased.ipynb
+++ b/docs/ja/releases/unreleased.ipynb
@@ -29,10 +29,10 @@
    "id": "8b31ba06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T09:36:19.730932Z",
-     "iopub.status.busy": "2026-07-22T09:36:19.730785Z",
-     "iopub.status.idle": "2026-07-22T09:36:19.823830Z",
-     "shell.execute_reply": "2026-07-22T09:36:19.823127Z"
+     "iopub.execute_input": "2026-07-23T01:49:44.613285Z",
+     "iopub.status.busy": "2026-07-23T01:49:44.613097Z",
+     "iopub.status.idle": "2026-07-23T01:49:44.731945Z",
+     "shell.execute_reply": "2026-07-23T01:49:44.731059Z"
     }
    },
    "outputs": [
@@ -42,15 +42,15 @@
      "text": [
       "Traceback (most recent last):\n",
       "    while checking if expression `x[W]` has type `float!`,\n",
-      "        defined at File \"/tmp/ipykernel_1343873/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_1577535/2363250674.py\", line 11, col 20-24\n",
       "    while inferring the type of expression `x[W]`,\n",
-      "        defined at File \"/tmp/ipykernel_1343873/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_1577535/2363250674.py\", line 11, col 20-24\n",
       "    while inferring the type of expression `x[W]`,\n",
-      "        defined at File \"/tmp/ipykernel_1343873/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_1577535/2363250674.py\", line 11, col 20-24\n",
       "    while checking if type `Array[N; binary!]` can be subscripted with (W): (float),\n",
-      "        defined at File \"/tmp/ipykernel_1343873/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_1577535/2363250674.py\", line 11, col 20-24\n",
       "\n",
-      "File \"/tmp/ipykernel_1343873/2363250674.py\", line 11, col 20-24:\n",
+      "File \"/tmp/ipykernel_1577535/2363250674.py\", line 11, col 20-24:\n",
       "\n",
       "    11  |          problem += x[W] # Error!\n",
       "                              ^^^^\n",
@@ -58,7 +58,7 @@
       "\u001b[1;31merror[E-TE0004]\u001b[0m Could not match actual type `float` with expected `natural`\n",
       "\n",
       "Mismatched on expression: `W`\n",
-      "    defined at File \"/tmp/ipykernel_1343873/2363250674.py\", line 11, col 20-24\n",
+      "    defined at File \"/tmp/ipykernel_1577535/2363250674.py\", line 11, col 20-24\n",
       "\n",
       "Hint: You can read the description and possible fix at https://jij-inc-jijmodeling.readthedocs-hosted.com/en/stable/error_codes/error/E-TE0004.html\n"
      ]
@@ -98,10 +98,10 @@
    "id": "46b7f69f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T09:36:19.825643Z",
-     "iopub.status.busy": "2026-07-22T09:36:19.825455Z",
-     "iopub.status.idle": "2026-07-22T09:36:21.740174Z",
-     "shell.execute_reply": "2026-07-22T09:36:21.739552Z"
+     "iopub.execute_input": "2026-07-23T01:49:44.734656Z",
+     "iopub.status.busy": "2026-07-23T01:49:44.734390Z",
+     "iopub.status.idle": "2026-07-23T01:49:47.095746Z",
+     "shell.execute_reply": "2026-07-23T01:49:47.094246Z"
     }
    },
    "outputs": [
@@ -161,11 +161,11 @@
    "id": "528ebd98",
    "metadata": {},
    "source": [
-    "### 端点に式を含む `jm.range` が内部エラーになる問題を修正\n",
+    "### 引数に式を含む `jm.range` が内部エラーになる問題を修正\n",
     "\n",
-    "これまで、`jm.range` の引数に `N - 1` のような計算式を渡すと、モデルの評価時に内部エラー（[E-CE0007](https://jij-inc-jijmodeling.readthedocs-hosted.com/en/v2.6.0/error_codes/error/E-CE0007.html)）が発生し、JijModeling 側のバグとして報告されていました。この問題は制約の `domain=` に限らず、総和の添字集合など `jm.range` を評価する全ての箇所で発生していました（リテラルや単独のプレースホルダーを端点とする `jm.range(N)` などは影響を受けません）。\n",
+    "これまで、`jm.range` の引数に `N - 1` のような計算式を渡すと、モデルの評価時に内部エラー（[E-CE0007](https://jij-inc-jijmodeling.readthedocs-hosted.com/en/v2.6.0/error_codes/error/E-CE0007.html)）が発生し、JijModeling 側のバグとして報告されていました。この問題は制約の `domain=` に限らず、総和の添字集合など `jm.range` を評価する全ての箇所で発生していました（リテラルや単独のプレースホルダーを引数とする `jm.range(N)` などは影響を受けません）。\n",
     "\n",
-    "今回の修正により、端点に式を含む range も正しく評価されるようになりました。"
+    "今回の修正により、引数に式を含む range も正しく評価されるようになりました。"
    ]
   },
   {
@@ -174,10 +174,10 @@
    "id": "53a87203",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-22T09:36:21.742007Z",
-     "iopub.status.busy": "2026-07-22T09:36:21.741878Z",
-     "iopub.status.idle": "2026-07-22T09:36:25.579095Z",
-     "shell.execute_reply": "2026-07-22T09:36:25.578319Z"
+     "iopub.execute_input": "2026-07-23T01:49:47.098382Z",
+     "iopub.status.busy": "2026-07-23T01:49:47.098173Z",
+     "iopub.status.idle": "2026-07-23T01:49:51.066190Z",
+     "shell.execute_reply": "2026-07-23T01:49:51.064948Z"
     }
    },
    "outputs": [
@@ -200,7 +200,7 @@
     {
      "data": {
       "text/plain": [
-       "Instance(raw=<builtins.Instance object at 0x5ca4a8ca9080>, annotations={})"
+       "Instance(raw=<builtins.Instance object at 0x6109c3a2f3c0>, annotations={})"
       ]
      },
      "execution_count": 3,

--- a/markdowns/en/releases/unreleased.md
+++ b/markdowns/en/releases/unreleased.md
@@ -75,8 +75,26 @@ problem
 
 +++
 
-### Bugfix 1
+### Fixed an internal error for `jm.range` with computed bounds
 
+Previously, passing a computed expression such as `N - 1` as a bound of `jm.range` caused an internal error ([E-CE0007](https://jij-inc-jijmodeling.readthedocs-hosted.com/en/v2.6.0/error_codes/error/E-CE0007.html)) when the model was evaluated, showing a message that asked users to report it as a bug in JijModeling. This affected not only `domain=` of constraints but every place where `jm.range` is evaluated, such as the index set of a summation (ranges with literal or bare-placeholder bounds like `jm.range(N)` were unaffected).
+
+With this fix, ranges whose bounds contain expressions now evaluate correctly.
+
+```{code-cell} ipython3
+import jijmodeling as jm
+
+@jm.Problem.define("RangeWithComputedBounds")
+def problem(problem: jm.DecoratedProblem):
+    N = problem.Natural()
+    x = problem.BinaryVar(shape=(N,))
+    problem += jm.sum(x[i] for i in jm.range(N - 1))
+    problem += problem.Constraint("fix", lambda i: x[i] == 0, domain=jm.range(N - 1))
+
+display(problem)
+
+problem.eval({"N": 4})
+```
 
 ## Other Changes
 

--- a/markdowns/en/releases/unreleased.md
+++ b/markdowns/en/releases/unreleased.md
@@ -75,11 +75,11 @@ problem
 
 +++
 
-### Fixed an internal error for `jm.range` with computed bounds
+### Fixed an internal error for `jm.range` with computed arguments
 
-Previously, passing a computed expression such as `N - 1` as a bound of `jm.range` caused an internal error ([E-CE0007](https://jij-inc-jijmodeling.readthedocs-hosted.com/en/v2.6.0/error_codes/error/E-CE0007.html)) when the model was evaluated, showing a message that asked users to report it as a bug in JijModeling. This affected not only `domain=` of constraints but every place where `jm.range` is evaluated, such as the index set of a summation (ranges with literal or bare-placeholder bounds like `jm.range(N)` were unaffected).
+Previously, passing a computed expression such as `N - 1` as a argument of `jm.range` caused an internal error ([E-CE0007](https://jij-inc-jijmodeling.readthedocs-hosted.com/en/v2.6.0/error_codes/error/E-CE0007.html)) when the model was evaluated, showing a message that asked users to report it as a bug in JijModeling. This affected not only `domain=` of constraints but every place where `jm.range` is evaluated, such as the index set of a summation (ranges with literal or bare-placeholder arguments like `jm.range(N)` were unaffected).
 
-With this fix, ranges whose bounds contain expressions now evaluate correctly.
+With this fix, ranges whose arguments contain expressions now evaluate correctly.
 
 ```{code-cell} ipython3
 import jijmodeling as jm

--- a/markdowns/ja/releases/unreleased.md
+++ b/markdowns/ja/releases/unreleased.md
@@ -75,11 +75,11 @@ problem
 
 +++
 
-### 端点に式を含む `jm.range` が内部エラーになる問題を修正
+### 引数に式を含む `jm.range` が内部エラーになる問題を修正
 
-これまで、`jm.range` の引数に `N - 1` のような計算式を渡すと、モデルの評価時に内部エラー（[E-CE0007](https://jij-inc-jijmodeling.readthedocs-hosted.com/en/v2.6.0/error_codes/error/E-CE0007.html)）が発生し、JijModeling 側のバグとして報告されていました。この問題は制約の `domain=` に限らず、総和の添字集合など `jm.range` を評価する全ての箇所で発生していました（リテラルや単独のプレースホルダーを端点とする `jm.range(N)` などは影響を受けません）。
+これまで、`jm.range` の引数に `N - 1` のような計算式を渡すと、モデルの評価時に内部エラー（[E-CE0007](https://jij-inc-jijmodeling.readthedocs-hosted.com/en/v2.6.0/error_codes/error/E-CE0007.html)）が発生し、JijModeling 側のバグとして報告されていました。この問題は制約の `domain=` に限らず、総和の添字集合など `jm.range` を評価する全ての箇所で発生していました（リテラルや単独のプレースホルダーを引数とする `jm.range(N)` などは影響を受けません）。
 
-今回の修正により、端点に式を含む range も正しく評価されるようになりました。
+今回の修正により、引数に式を含む range も正しく評価されるようになりました。
 
 ```{code-cell} ipython3
 import jijmodeling as jm

--- a/markdowns/ja/releases/unreleased.md
+++ b/markdowns/ja/releases/unreleased.md
@@ -75,8 +75,26 @@ problem
 
 +++
 
-### バグ修正1：
+### 端点に式を含む `jm.range` が内部エラーになる問題を修正
 
+これまで、`jm.range` の引数に `N - 1` のような計算式を渡すと、モデルの評価時に内部エラー（[E-CE0007](https://jij-inc-jijmodeling.readthedocs-hosted.com/en/v2.6.0/error_codes/error/E-CE0007.html)）が発生し、JijModeling 側のバグとして報告されていました。この問題は制約の `domain=` に限らず、総和の添字集合など `jm.range` を評価する全ての箇所で発生していました（リテラルや単独のプレースホルダーを端点とする `jm.range(N)` などは影響を受けません）。
+
+今回の修正により、端点に式を含む range も正しく評価されるようになりました。
+
+```{code-cell} ipython3
+import jijmodeling as jm
+
+@jm.Problem.define("RangeWithComputedBounds")
+def problem(problem: jm.DecoratedProblem):
+    N = problem.Natural()
+    x = problem.BinaryVar(shape=(N,))
+    problem += jm.sum(x[i] for i in jm.range(N - 1))
+    problem += problem.Constraint("fix", lambda i: x[i] == 0, domain=jm.range(N - 1))
+
+display(problem)
+
+problem.eval({"N": 4})
+```
 
 ## その他の変更
 


### PR DESCRIPTION
# Description

Adds the unreleased release note (ja/en, markdown + synced notebooks) for the JijModeling fix of the internal error E-CE0007 that occurred when `jm.range` was given computed bounds such as `N - 1` — e.g. `domain=jm.range(N - 1)` in constraints or sums over such ranges.

- JijModeling backlog: [GEN-2466](https://app.notion.com/p/fe2d05f219714f4994695f323e898e68)
- Corresponding JijModeling branch: `konn/range-in-domain` (fix commit `ca6d179f`)
- The example cell was verified to run against a wheel built from that branch (3 constraints generated, `eval` succeeds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)