### PR TITLE
docs(releases): refresh contextual type mismatch output

### DIFF
--- a/docs/en/releases/unreleased.ipynb
+++ b/docs/en/releases/unreleased.ipynb
@@ -29,10 +29,10 @@
    "id": "cc6ffcae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T01:49:35.908360Z",
-     "iopub.status.busy": "2026-07-23T01:49:35.908197Z",
-     "iopub.status.idle": "2026-07-23T01:49:36.053034Z",
-     "shell.execute_reply": "2026-07-23T01:49:36.051442Z"
+     "iopub.execute_input": "2026-07-24T04:40:22.291844Z",
+     "iopub.status.busy": "2026-07-24T04:40:22.291633Z",
+     "iopub.status.idle": "2026-07-24T04:40:22.422681Z",
+     "shell.execute_reply": "2026-07-24T04:40:22.421723Z"
     }
    },
    "outputs": [
@@ -42,23 +42,22 @@
      "text": [
       "Traceback (most recent last):\n",
       "    while checking if expression `x[W]` has type `float!`,\n",
-      "        defined at File \"/tmp/ipykernel_1577398/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_2522867/2363250674.py\", line 11, col 20-24\n",
       "    while inferring the type of expression `x[W]`,\n",
-      "        defined at File \"/tmp/ipykernel_1577398/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_2522867/2363250674.py\", line 11, col 20-24\n",
       "    while inferring the type of expression `x[W]`,\n",
-      "        defined at File \"/tmp/ipykernel_1577398/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_2522867/2363250674.py\", line 11, col 20-24\n",
       "    while checking if type `Array[N; binary!]` can be subscripted with (W): (float),\n",
-      "        defined at File \"/tmp/ipykernel_1577398/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_2522867/2363250674.py\", line 11, col 20-24\n",
+      "    while checking if expression `W` has type `natural`,\n",
+      "        defined at File \"/tmp/ipykernel_2522867/2363250674.py\", line 11, col 22-23\n",
       "\n",
-      "File \"/tmp/ipykernel_1577398/2363250674.py\", line 11, col 20-24:\n",
+      "File \"/tmp/ipykernel_2522867/2363250674.py\", line 11, col 22-23:\n",
       "\n",
       "    11  |          problem += x[W] # Error!\n",
-      "                              ^^^^\n",
+      "                                ^\n",
       "\n",
-      "\u001b[1;31merror[E-TE0004]\u001b[0m Could not match actual type `float` with expected `natural`\n",
-      "\n",
-      "Mismatched on expression: `W`\n",
-      "    defined at File \"/tmp/ipykernel_1577398/2363250674.py\", line 11, col 20-24\n",
+      "\u001b[1;31merror[E-TE0004]\u001b[0m Could not match actual type `float` with expected `natural` on an expression `W`\n",
       "\n",
       "Hint: You can read the description and possible fix at https://jij-inc-jijmodeling.readthedocs-hosted.com/en/stable/error_codes/error/E-TE0004.html\n"
      ]
@@ -98,10 +97,10 @@
    "id": "69b81dd7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T01:49:36.056078Z",
-     "iopub.status.busy": "2026-07-23T01:49:36.055865Z",
-     "iopub.status.idle": "2026-07-23T01:49:38.457315Z",
-     "shell.execute_reply": "2026-07-23T01:49:38.455946Z"
+     "iopub.execute_input": "2026-07-24T04:40:22.424480Z",
+     "iopub.status.busy": "2026-07-24T04:40:22.424326Z",
+     "iopub.status.idle": "2026-07-24T04:40:24.443979Z",
+     "shell.execute_reply": "2026-07-24T04:40:24.443009Z"
     }
    },
    "outputs": [
@@ -174,10 +173,10 @@
    "id": "9bcf3dec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T01:49:38.460346Z",
-     "iopub.status.busy": "2026-07-23T01:49:38.460123Z",
-     "iopub.status.idle": "2026-07-23T01:49:43.470418Z",
-     "shell.execute_reply": "2026-07-23T01:49:43.469624Z"
+     "iopub.execute_input": "2026-07-24T04:40:24.445973Z",
+     "iopub.status.busy": "2026-07-24T04:40:24.445817Z",
+     "iopub.status.idle": "2026-07-24T04:40:28.876766Z",
+     "shell.execute_reply": "2026-07-24T04:40:28.876002Z"
     }
    },
    "outputs": [
@@ -200,7 +199,7 @@
     {
      "data": {
       "text/plain": [
-       "Instance(raw=<builtins.Instance object at 0x62ead482c0b0>, annotations={})"
+       "Instance(raw=<builtins.Instance object at 0x581054970860>, annotations={})"
       ]
      },
      "execution_count": 3,

--- a/docs/ja/releases/unreleased.ipynb
+++ b/docs/ja/releases/unreleased.ipynb
@@ -29,10 +29,10 @@
    "id": "8b31ba06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T01:49:44.613285Z",
-     "iopub.status.busy": "2026-07-23T01:49:44.613097Z",
-     "iopub.status.idle": "2026-07-23T01:49:44.731945Z",
-     "shell.execute_reply": "2026-07-23T01:49:44.731059Z"
+     "iopub.execute_input": "2026-07-24T04:40:21.507171Z",
+     "iopub.status.busy": "2026-07-24T04:40:21.506969Z",
+     "iopub.status.idle": "2026-07-24T04:40:21.626798Z",
+     "shell.execute_reply": "2026-07-24T04:40:21.625820Z"
     }
    },
    "outputs": [
@@ -42,23 +42,22 @@
      "text": [
       "Traceback (most recent last):\n",
       "    while checking if expression `x[W]` has type `float!`,\n",
-      "        defined at File \"/tmp/ipykernel_1577535/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_2522789/2363250674.py\", line 11, col 20-24\n",
       "    while inferring the type of expression `x[W]`,\n",
-      "        defined at File \"/tmp/ipykernel_1577535/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_2522789/2363250674.py\", line 11, col 20-24\n",
       "    while inferring the type of expression `x[W]`,\n",
-      "        defined at File \"/tmp/ipykernel_1577535/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_2522789/2363250674.py\", line 11, col 20-24\n",
       "    while checking if type `Array[N; binary!]` can be subscripted with (W): (float),\n",
-      "        defined at File \"/tmp/ipykernel_1577535/2363250674.py\", line 11, col 20-24\n",
+      "        defined at File \"/tmp/ipykernel_2522789/2363250674.py\", line 11, col 20-24\n",
+      "    while checking if expression `W` has type `natural`,\n",
+      "        defined at File \"/tmp/ipykernel_2522789/2363250674.py\", line 11, col 22-23\n",
       "\n",
-      "File \"/tmp/ipykernel_1577535/2363250674.py\", line 11, col 20-24:\n",
+      "File \"/tmp/ipykernel_2522789/2363250674.py\", line 11, col 22-23:\n",
       "\n",
       "    11  |          problem += x[W] # Error!\n",
-      "                              ^^^^\n",
+      "                                ^\n",
       "\n",
-      "\u001b[1;31merror[E-TE0004]\u001b[0m Could not match actual type `float` with expected `natural`\n",
-      "\n",
-      "Mismatched on expression: `W`\n",
-      "    defined at File \"/tmp/ipykernel_1577535/2363250674.py\", line 11, col 20-24\n",
+      "\u001b[1;31merror[E-TE0004]\u001b[0m Could not match actual type `float` with expected `natural` on an expression `W`\n",
       "\n",
       "Hint: You can read the description and possible fix at https://jij-inc-jijmodeling.readthedocs-hosted.com/en/stable/error_codes/error/E-TE0004.html\n"
      ]
@@ -98,10 +97,10 @@
    "id": "46b7f69f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T01:49:44.734656Z",
-     "iopub.status.busy": "2026-07-23T01:49:44.734390Z",
-     "iopub.status.idle": "2026-07-23T01:49:47.095746Z",
-     "shell.execute_reply": "2026-07-23T01:49:47.094246Z"
+     "iopub.execute_input": "2026-07-24T04:40:21.628722Z",
+     "iopub.status.busy": "2026-07-24T04:40:21.628554Z",
+     "iopub.status.idle": "2026-07-24T04:40:23.761377Z",
+     "shell.execute_reply": "2026-07-24T04:40:23.760582Z"
     }
    },
    "outputs": [
@@ -174,10 +173,10 @@
    "id": "53a87203",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-23T01:49:47.098382Z",
-     "iopub.status.busy": "2026-07-23T01:49:47.098173Z",
-     "iopub.status.idle": "2026-07-23T01:49:51.066190Z",
-     "shell.execute_reply": "2026-07-23T01:49:51.064948Z"
+     "iopub.execute_input": "2026-07-24T04:40:23.763124Z",
+     "iopub.status.busy": "2026-07-24T04:40:23.762973Z",
+     "iopub.status.idle": "2026-07-24T04:40:28.373590Z",
+     "shell.execute_reply": "2026-07-24T04:40:28.372870Z"
     }
    },
    "outputs": [
@@ -200,7 +199,7 @@
     {
      "data": {
       "text/plain": [
-       "Instance(raw=<builtins.Instance object at 0x6109c3a2f3c0>, annotations={})"
+       "Instance(raw=<builtins.Instance object at 0x60e922466710>, annotations={})"
       ]
      },
      "execution_count": 3,


### PR DESCRIPTION
# Description

Re-executes the English and Japanese unreleased notebooks with the contextual TypeMismatch changes from the corresponding JijModeling branch.

The rendered example now:

- highlights only the mismatching `W` subscript;
- includes the direct `W: natural` type-checking frame once; and
- shows the mismatched expression inline in `E-TE0004` without the redundant trailing location paragraph.

## Validation

- Executed both unreleased notebooks with Jupytext using the locally built JijModeling wheel.
- Verified the paired Markdown sources remain synchronized.